### PR TITLE
Make use of GitHub Actions to Build box on Pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+# This workflow simply builds box on pushes.
+name: "Build"
+on: push
+
+jobs:
+    build-ubuntu:
+        # This job builds box on Ubuntu.
+        name: "Build - Ubuntu"
+        runs-on: ubuntu-latest
+        steps:
+        - name: "Checkout the Repo"
+          uses: actions/checkout@v2
+        - name: "Make box"
+          run: "make box"
+    build-macos:
+        # This job builds box on macOS.
+        name: "Build - macOS"
+        runs-on: macos-latest
+        steps:
+        - name: "Checkout the Repo"
+          uses: actions/checkout@v2
+        - name: "Make box"
+          run: "make box"


### PR DESCRIPTION
Because two CIs are better than one!

Add a GitHub Workflow, which builds box on pushes.
It builds box on Linux and on macOS.

